### PR TITLE
Included wiki_link and wiki_pageid in artist model

### DIFF
--- a/api/models/artists.js
+++ b/api/models/artists.js
@@ -38,6 +38,12 @@ module.exports = function (context) {
         source_link: {
             type: context.Sequelize.TEXT
         }
+        wiki_link: {
+            type: context.Sequelize.TEXT
+        }
+        wiki_pageid: {
+            type: context.Sequelize.TEXT
+        }
     }, {
         freezeTableName: true // Model tableName will be the same as the model name
     });


### PR DESCRIPTION
Included wiki_link and wiki_pageid in artist model. This can be used by group 3 and 4 to extract relationships.