### PR TITLE
Tablesync fix

### DIFF
--- a/api/models/artists.js
+++ b/api/models/artists.js
@@ -37,10 +37,10 @@ module.exports = function (context) {
         },
         source_link: {
             type: context.Sequelize.TEXT
-        }
+        },
         wiki_link: {
             type: context.Sequelize.TEXT
-        }
+        },
         wiki_pageid: {
             type: context.Sequelize.TEXT
         }

--- a/app.js
+++ b/app.js
@@ -20,8 +20,9 @@ var config = {
 require(path.join(__dirname, "index.js")).connect(function (context) {
 
 
-    context.sequelize.sync({force: true}).then(function () {
-        SwaggerExpress.create(config, function (err, swaggerExpress) {
+    SwaggerExpress.create(config, function (err, swaggerExpress) {
+        context.sequelize.sync({force: true}).then(function () {
+
             if (err) {
                 throw err;
             }

--- a/index.js
+++ b/index.js
@@ -88,6 +88,6 @@ module.exports = {
         if(context) {
             return context;
         }
-        console.log('Failed to retrieve context: context doesn\' exist.');
+        console.log('Failed to retrieve context: context doesn\'t exist.');
     }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
         const path = require('path');
         const Sequelize = require('sequelize');
 
-        console.log('start: Initializing context');
+        console.log('Initializing context');
         // Initialize the context
         context = {
             fs: fs,
@@ -44,9 +44,7 @@ module.exports = {
         return context;
     },
     connect: function(callback) {
-        console.log('Connect called');
-        const context = this.getContext();
-        console.log('called getContext, now connecting do db');
+        const context = this.createContext();
 
         return context.sequelize
             .authenticate()
@@ -62,12 +60,7 @@ module.exports = {
                 return process.exit(1);
             });
     },
-    getContext: function() {
-        if(context) {
-            console.log('getContext: Returning cached context');
-            return context;
-        }
-        console.log('getContext: creating new context');
+    createContext: function() {
         context = this.start();
         var config = require(__dirname + '/config/postgresConfig.json');
 
@@ -90,5 +83,11 @@ module.exports = {
         });
 
         return context;
+    },
+    getContext: function() {
+        if(context) {
+            return context;
+        }
+        console.log('Failed to retrieve context: context doesn\' exist.');
     }
 }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
         const path = require('path');
         const Sequelize = require('sequelize');
 
+        console.log('start: Initializing context');
         // Initialize the context
         context = {
             fs: fs,
@@ -43,7 +44,9 @@ module.exports = {
         return context;
     },
     connect: function(callback) {
+        console.log('Connect called');
         const context = this.getContext();
+        console.log('called getContext, now connecting do db');
 
         return context.sequelize
             .authenticate()
@@ -60,7 +63,12 @@ module.exports = {
             });
     },
     getContext: function() {
-        const context = this.start();
+        if(context) {
+            console.log('getContext: Returning cached context');
+            return context;
+        }
+        console.log('getContext: creating new context');
+        context = this.start();
         var config = require(__dirname + '/config/postgresConfig.json');
 
         context.config = config;


### PR DESCRIPTION
Split up getContext into two functions:
createContext creates a new context and returns it, should be called by connect.
getContext retrieves the created context, should be called by the controllers.
Fixes #31 

Fixes issue where tables would not be created by sync({force: true}) 
Many thanks to @TimHenkelmann  and @ShilpaGhanashyamGore 